### PR TITLE
allow completions for inputminted with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If you want file paths to be completed, you can use [`autocomplete-paths`](https
         ".*"
       ]
       prefixes: [
-        "\\\\inputminted\\{.*\\}\\{"
+        "\\\\inputminted(\\[.*?\\])?\\{.*\\}\\{"
       ]
       relative: true
       scopes: [


### PR DESCRIPTION
This would allow completions for `inputminted` with options:
e.g.: 
```latex
\inputminted[frame=lines, linenos, firstnumber=1, firstline=23, lastline=33]{julia}{./src/typo.jl}
```